### PR TITLE
fix: prevent knockback from pushing enemies through walls

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -243,6 +243,12 @@ export class EnemyManager {
     return new this.THREE.Vector3(v.x * c - v.z * s, 0, v.x * s + v.z * c).normalize();
   }
 
+  applyKnockback(enemy, vector) {
+    if (!enemy || !vector) return;
+    const step = vector.clone ? vector.clone() : new this.THREE.Vector3(vector.x || 0, vector.y || 0, vector.z || 0);
+    this._moveWithCollisions(enemy, step);
+  }
+
   _moveWithCollisions(enemy, step) {
     // Attempt axis-separated movement with AABB checks against static objects
     const THREE = this.THREE;
@@ -404,6 +410,7 @@ export class EnemyManager {
       separation: (...args) => this.separation(...args),
       avoidObstacles: (origin, desiredDir, maxDist) => this._avoidObstacles(origin, desiredDir, maxDist),
       moveWithCollisions: (enemy, step) => this._moveWithCollisions(enemy, step),
+      applyKnockback: (enemy, vec) => this.applyKnockback(enemy, vec),
       // Count allies within a radius around a position, excluding an optional self root
       alliesNearbyCount: (position, radius = 8.0, selfRoot = null) => {
         const r2 = Math.max(0, radius) * Math.max(0, radius);

--- a/src/weapons/dmr.js
+++ b/src/weapons/dmr.js
@@ -15,7 +15,7 @@ export class DMR extends Weapon {
   }
 
   onFire(ctx) {
-    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager } = ctx;
+    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager, applyKnockback } = ctx;
     // Recoil: 2.0–3.0°, no FOV kick
     const pitch = (3.5 + Math.random() * 1.2) * (Math.PI/180);
     const yaw = ((Math.random()*2 - 1) * 0.8) * (Math.PI/180);
@@ -37,7 +37,7 @@ export class DMR extends Weapon {
       res.enemyRoot.userData.hp -= dmg;
       // stronger knockback and brief slow on hit (non-boss)
       const push = camDir.clone().multiplyScalar(0.35);
-      res.enemyRoot.position.add(push);
+      applyKnockback?.(res.enemyRoot, push);
       effects?.spawnBulletImpact?.(end, res.hitFace?.normal);
       if (S && S.impactFlesh) S.impactFlesh();
       if (S && S.enemyPain) S.enemyPain(res.enemyRoot?.userData?.type || 'grunt');

--- a/src/weapons/rifle.js
+++ b/src/weapons/rifle.js
@@ -22,7 +22,7 @@ export class Rifle extends Weapon {
   }
 
   onFire(ctx) {
-    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager } = ctx;
+    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager, applyKnockback } = ctx;
     // Recoil: modest per-shot, vertical only
     const pitch = (1.4 + Math.random() * 0.4) * (Math.PI/180);
     ctx.applyRecoil?.({ pitchRad: pitch });
@@ -67,7 +67,7 @@ export class Rifle extends Weapon {
       res.enemyRoot.userData.hp -= dmg;
       // pushback
       const dir2 = new THREE.Vector3(); camera.getWorldDirection(dir2);
-      res.enemyRoot.position.add(dir2.clone().multiplyScalar(0.16));
+      applyKnockback?.(res.enemyRoot, dir2.clone().multiplyScalar(0.16));
       effects?.spawnBulletImpact?.(end, res.hitFace?.normal);
       if (S && S.impactFlesh) S.impactFlesh();
       if (S && S.enemyPain) S.enemyPain(res.enemyRoot?.userData?.type || 'grunt');

--- a/src/weapons/smg.js
+++ b/src/weapons/smg.js
@@ -28,7 +28,7 @@ export class SMG extends Weapon {
   }
 
   onFire(ctx) {
-    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager } = ctx;
+    const { THREE, camera, raycaster, enemyManager, objects, effects, S, pickups, addScore, addComboAction, obstacleManager, applyKnockback } = ctx;
     // Recoil: visible per‑shot 0.8–1.2° pitch, ±0.5° yaw; fast recovery; no FOV kick
     const pitch = (1.4 + Math.random() * 0.6) * (Math.PI/180);
     const yaw = ((Math.random()*2 - 1) * 0.8) * (Math.PI/180);
@@ -60,7 +60,7 @@ export class SMG extends Weapon {
       const dmg = base * fall;
       res.enemyRoot.userData.hp -= dmg;
       // tiny pushback
-      res.enemyRoot.position.add(dir.clone().multiplyScalar(0.12));
+      applyKnockback?.(res.enemyRoot, dir.clone().multiplyScalar(0.12));
       effects?.spawnBulletImpact?.(end, res.hitFace?.normal);
       if (S && S.impactFlesh) S.impactFlesh();
       if (S && S.enemyPain) S.enemyPain(res.enemyRoot?.userData?.type || 'grunt');

--- a/src/weapons/system.js
+++ b/src/weapons/system.js
@@ -88,7 +88,8 @@ export class WeaponSystem {
       addComboAction: this.addComboAction,
       combo: this.combo,
       addTracer: this.addTracer,
-      applyRecoil: this.applyRecoil
+      applyRecoil: this.applyRecoil,
+      applyKnockback: (enemy, vec) => this.enemyManager?.applyKnockback?.(enemy, vec)
     };
   }
 


### PR DESCRIPTION
## Summary
- Add `applyKnockback` helper to EnemyManager and expose via context
- Use collision-aware knockback in weapons instead of directly changing enemy positions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a4d94403388322b5a97623fc3413e3