### PR TITLE
Delay wave advancement until Hydraclone clones are cleared

### DIFF
--- a/src/bosses/hydraclone.js
+++ b/src/bosses/hydraclone.js
@@ -140,6 +140,10 @@ export class Hydraclone {
     return inst;
   }
 
+  static hasPending() {
+    return HydraGlobal.active + HydraGlobal.queue.length > 0;
+  }
+
   // --- Temporary mirror clones that retrace recent player path ---
   _spawnMirrorClones(ctx) {
     if (this._playerPath.length < 2) return;

--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -7,6 +7,7 @@ import { RusherEnemy } from './rusher.js';
 import { BailiffEnemy } from './bailiff.js';
 import { SwarmWarden } from './warden.js';
 import { BossManager } from '../bosses/manager.js';
+import { Hydraclone } from '../bosses/hydraclone.js';
 
 export class EnemyManager {
   constructor(THREE, scene, mats, objects = [], getPlayer = null) {
@@ -905,14 +906,14 @@ export class EnemyManager {
   
     const bossActive = !!(this.bossManager && this.bossManager.active && this.bossManager.boss);
     if (!this.suspendWaves) {
-      if (this.alive <= 0 && !bossActive && !this._advancingWave) {
+      if (this.alive <= 0 && !bossActive && !Hydraclone.hasPending() && !this._advancingWave) {
         this._advancingWave = true;
         this.wave++;
         this.startWave();
         this._advancingWave = false;
       }
     }
-  }  
+  }
 
   // --- Boss integration helpers ---
 


### PR DESCRIPTION
## Summary
- add Hydraclone.hasPending helper to expose active/queued clones
- gate EnemyManager wave advancement on Hydraclone.hasPending

## Testing
- `node --check src/bosses/hydraclone.js`
- `node --check src/enemies/manager.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a789d14ddc83228aa52d8492b04d7c