### PR TITLE
Add BeamSaber short-range energy weapon

### DIFF
--- a/assets/icons/weapon-beamsaber.svg
+++ b/assets/icons/weapon-beamsaber.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="64" height="64">
+  <g fill="currentColor">
+    <rect x="30" y="8" width="4" height="32" rx="1"/>
+    <rect x="24" y="40" width="16" height="4" rx="1"/>
+    <rect x="28" y="44" width="8" height="12" rx="1"/>
+  </g>
+</svg>

--- a/src/main.js
+++ b/src/main.js
@@ -291,7 +291,7 @@ function updateHUD(){
   const w = weaponSystem ? weaponSystem.current : null;
   if (weaponNameEl) weaponNameEl.textContent = w ? w.name : 'Rifle';
   if (weaponIconEl) {
-    const iconMap = { Rifle:'assets/icons/weapon-rifle.svg', SMG:'assets/icons/weapon-smg.svg', Shotgun:'assets/icons/weapon-shotgun.svg', DMR:'assets/icons/weapon-dmr.svg', Pistol:'assets/icons/weapon-pistol.svg' };
+    const iconMap = { Rifle:'assets/icons/weapon-rifle.svg', SMG:'assets/icons/weapon-smg.svg', Shotgun:'assets/icons/weapon-shotgun.svg', DMR:'assets/icons/weapon-dmr.svg', Pistol:'assets/icons/weapon-pistol.svg', BeamSaber:'assets/icons/weapon-beamsaber.svg' };
     weaponIconEl.src = iconMap[w?.name] || iconMap.Rifle;
   }
   hpEl.textContent=hp; ammoEl.textContent=ammoVal; magEl.textContent=reserveVal; scoreEl.textContent=score; if (bestEl) bestEl.textContent = best; if(waveEl) waveEl.textContent = enemyManager.wave;

--- a/src/progression.js
+++ b/src/progression.js
@@ -19,9 +19,9 @@ export class Progression {
   _loadUnlocks(){
     try {
       const s = localStorage.getItem(this.UNLOCKS_KEY);
-      return s ? JSON.parse(s) : { bestWave:0, smg:false, shotgun:false, rifle:false, dmr:false };
+      return s ? JSON.parse(s) : { bestWave:0, smg:false, shotgun:false, rifle:false, dmr:false, beamsaber:false };
     } catch {
-      return { bestWave:0, smg:false, shotgun:false, rifle:false, dmr:false };
+      return { bestWave:0, smg:false, shotgun:false, rifle:false, dmr:false, beamsaber:false };
     }
   }
   _saveUnlocks(){ try { localStorage.setItem(this.UNLOCKS_KEY, JSON.stringify(this.unlocks)); } catch {} }
@@ -45,6 +45,7 @@ export class Progression {
     if (wave === 9) { this._presentOffer(['SMG','Rifle']); return; }
     if (wave === 9) { this._presentOffer(['SMG','Shotgun']); return; }
     if (wave === 11) { this._presentOffer(['Rifle','DMR']); return; }
+    if (wave === 12) { this._presentOffer(['DMR','BeamSaber']); return; }
 
     // After wave 5, unlock persistently and continue normal offers on even waves
     if (wave > (this.unlocks.bestWave||0)){
@@ -53,6 +54,7 @@ export class Progression {
       if (wave >= 5) this.unlocks.smg = true;
       // rifle unlocked after first boss via main.js hook
       // dmr unlocked after second boss via main.js hook
+      if (wave >= 12) this.unlocks.beamsaber = true;
       this._saveUnlocks();
     }
     if (wave >= 6 && (wave % 2) === 0){
@@ -175,7 +177,7 @@ export class Progression {
   }
 
   _iconFor(name){
-    const map = { Rifle:'assets/icons/weapon-rifle.svg', SMG:'assets/icons/weapon-smg.svg', Shotgun:'assets/icons/weapon-shotgun.svg', DMR:'assets/icons/weapon-dmr.svg', Pistol:'assets/icons/weapon-pistol.svg' };
+    const map = { Rifle:'assets/icons/weapon-rifle.svg', SMG:'assets/icons/weapon-smg.svg', Shotgun:'assets/icons/weapon-shotgun.svg', DMR:'assets/icons/weapon-dmr.svg', Pistol:'assets/icons/weapon-pistol.svg', BeamSaber:'assets/icons/weapon-beamsaber.svg' };
     return map[name] || map.Rifle;
   }
 }

--- a/src/weapons/beamsaber.js
+++ b/src/weapons/beamsaber.js
@@ -1,0 +1,76 @@
+import { Weapon } from './base.js';
+
+export class BeamSaber extends Weapon {
+  constructor() {
+    super({
+      name: 'BeamSaber',
+      mode: 'semi',
+      fireDelayMs: 500,
+      magSize: 1,
+      reserve: 0
+    });
+  }
+
+  onFire(ctx) {
+    const { THREE, camera, raycaster, enemyManager, effects, S, pickups, addScore, addComboAction, applyKnockback, objects } = ctx;
+    const origin = camera.getWorldPosition(new THREE.Vector3());
+    const dir = camera.getWorldDirection(new THREE.Vector3()).normalize();
+    const range = 5;
+    const end = origin.clone().add(dir.clone().multiplyScalar(range));
+
+    raycaster.set(origin, dir);
+    raycaster.far = range;
+    const candidates = enemyManager.getEnemyRaycastTargets ? enemyManager.getEnemyRaycastTargets() : Array.from(enemyManager.enemies);
+    const hits = candidates.length ? raycaster.intersectObjects(candidates, true) : [];
+    const handled = new Set();
+
+    if (S && S.shot) S.shot('dmr');
+    effects?.spawnMuzzleFlash?.(0.3);
+
+    for (const hit of hits) {
+      if (hit.distance > range) continue;
+      let obj = hit.object;
+      while (obj && !enemyManager.enemies.has(obj)) obj = obj.parent;
+      if (!obj || handled.has(obj)) continue;
+      handled.add(obj);
+
+      try { window._HUD && window._HUD.showHitmarker && window._HUD.showHitmarker(); } catch(_) {}
+      obj.userData.hp -= 40;
+      applyKnockback?.(obj, dir.clone().multiplyScalar(0.25));
+      effects?.spawnBulletImpact?.(hit.point, hit.face?.normal);
+      if (S && S.impactFlesh) S.impactFlesh();
+      if (S && S.enemyPain) S.enemyPain(obj?.userData?.type || 'grunt');
+      effects?.spawnBulletDecal?.(hit.point, hit.face?.normal, { size: 0.12, ttl: 10, color: 0x101010, softness: 0.5, object: hit.object, owner: obj, attachTo: obj });
+
+      if (obj.userData.hp <= 0) {
+        effects?.enemyDeath?.(obj.position.clone());
+        if (S && S.enemyDeath) S.enemyDeath(obj?.userData?.type || 'grunt');
+        const eType = obj?.userData?.type;
+        if (eType === 'tank') {
+          pickups?.dropMultiple?.('random', obj.position.clone(), 3 + (Math.random() * 2 | 0));
+        } else {
+          pickups?.maybeDrop?.(obj.position.clone());
+        }
+        enemyManager.remove(obj);
+        const finalScore = Math.round(100 * (ctx.combo?.multiplier || 1));
+        addScore?.(finalScore);
+        addComboAction?.(1);
+      } else {
+        addComboAction?.(0.25);
+      }
+    }
+
+    if (hits.length === 0 && objects && objects.length) {
+      const worldHits = raycaster.intersectObjects(objects, true);
+      if (worldHits.length) {
+        const h = worldHits[0];
+        effects?.spawnBulletImpact?.(h.point, h.face?.normal);
+      }
+    }
+
+    if (ctx.addTracer) ctx.addTracer(origin, end);
+    this.ammoInMag = 1;
+    ctx.updateHUD?.();
+  }
+}
+

--- a/src/weapons/system.js
+++ b/src/weapons/system.js
@@ -5,6 +5,7 @@ import { DMR } from './dmr.js';
 import { Pistol } from './pistol.js';
 import { GrenadePistol } from './grenadepistol.js';
 import { Minigun } from './minigun.js';
+import { BeamSaber } from './beamsaber.js';
 
 // WeaponSystem orchestrates current weapon, input mapping, and HUD sync
 export class WeaponSystem {
@@ -52,6 +53,7 @@ export class WeaponSystem {
     if (name === 'Minigun') return { baseScale: 1.0, minAlpha: 0.55, k: 1.0, thickPx: 2, gapPx: 8, lenPx: 8 };
     if (name === 'DMR') return { baseScale: 0.8, minAlpha: 0.78, k: 0.45, thickPx: 2, gapPx: 4, lenPx: 4 };
     if (name === 'Shotgun') return { baseScale: 1.2, minAlpha: 0.65, k: 1.2, thickPx: 2, gapPx: 20, lenPx: 8 };
+    if (name === 'BeamSaber') return { baseScale: 0.7, minAlpha: 0.8, k: 0.4, thickPx: 2, gapPx: 3, lenPx: 3 };
     return def;
   }
 
@@ -161,6 +163,7 @@ export class WeaponSystem {
     if (unlocks?.shotgun) list.push({ name:'Shotgun', make: ()=> new Shotgun() });
     if (unlocks?.dmr) list.push({ name:'DMR', make: ()=> new DMR() });
     if (unlocks?.minigun) list.push({ name:'Minigun', make: ()=> new Minigun() });
+    if (unlocks?.beamsaber) list.push({ name:'BeamSaber', make: ()=> new BeamSaber() });
     return list;
   }
 

--- a/src/weapons/view.js
+++ b/src/weapons/view.js
@@ -209,20 +209,26 @@ export class WeaponView {
         addSight(muzzleZ + L*0.7);
         addSight(muzzleZ + L + 0.12);
       };
-  
+
       const makeGrenade = ()=>{
         const L = 0.20, D = 0.09;
         addBox(D, D, L, 0.0, -0.01, muzzleZ + L*0.5, metal);
         addBox(D*2.6, D*1.6, 0.16, -0.05, -0.015, muzzleZ + L + 0.08, body);
         addSight(muzzleZ + L + 0.06, 0.014, 0.02);
       };
-  
+
+      const makeBeamSaber = ()=>{
+        const L = 0.18, D = 0.04;
+        addBox(D, D, L, 0.0, -0.02, muzzleZ + L*0.5, metal);
+      };
+
       switch ((name||'').toLowerCase()){
         case 'pistol': makePistol(); break;
         case 'smg': makeSMG(); break;
         case 'shotgun': makeShotgun(); break;
         case 'dmr': makeDMR(); break;
         case 'grenade': makeGrenade(); break;
+        case 'beamsaber': makeBeamSaber(); break;
         case 'rifle': default: makeRifle(); break;
       }
   


### PR DESCRIPTION
## Summary
- add BeamSaber weapon that projects a 5m piercing beam and deals 40 damage
- integrate BeamSaber into weapon system, progression unlocks, and HUD icons
- include simple first-person model and icon asset

## Testing
- `npm test` (fails: Could not read package.json)


------
https://chatgpt.com/codex/tasks/task_e_68a790e995948322a4b48b61de508a45