### PR TITLE
Wire pickups into enemy AI and hydrate Hydraclone drops

### DIFF
--- a/src/bosses/hydraclone.js
+++ b/src/bosses/hydraclone.js
@@ -291,6 +291,15 @@ export class Hydraclone {
       this._didRegisterDeath = true;
       for (const c of this._mirrorClones) { ctx.scene.remove(c.root); }
       this._mirrorClones.length = 0;
+      const pos = this.root.position.clone();
+      if (ctx.pickups) {
+        if (this.gen === 0) {
+          ctx.pickups.dropMultiple('med', pos, 1);
+          ctx.pickups.dropMultiple('ammo', pos, 4);
+        } else {
+          ctx.pickups.dropMultiple('random', pos, 1);
+        }
+      }
       // removal is handled by EnemyManager; nothing else to do here
       return;
     }

--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -655,6 +655,7 @@ export class EnemyManager {
     ctx.objects = this.objects;
     ctx.scene = this.scene;
     ctx.onPlayerDamage = onPlayerDamage;
+    ctx.pickups = this.pickups;
 
     // 3) One-time helper wiring (from main). Create once.
     if (!ctx._spawnBullet) {

--- a/src/main.js
+++ b/src/main.js
@@ -178,6 +178,7 @@ effects.muzzleEnabled = true;
 // First-person simple weapon view (barrel meshes)
 const weaponView = new WeaponView(THREE, camera);
 const pickups = new Pickups(THREE, scene);
+enemyManager.pickups = pickups;
 
 // Wire obstacle manager hooks now that managers exist
 obstacleManager.enemyManager = enemyManager;


### PR DESCRIPTION
## Summary
- Expose global pickups to enemies and AI context
- Hydraclone drops med/ammo or random pickups on death

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7910654e08322a0eaaa0ab0ed345c