### PR TITLE
Add beam saber audio effects

### DIFF
--- a/src/sfx.js
+++ b/src/sfx.js
@@ -158,6 +158,42 @@ export class SFX {
     body.start(t0); body.stop(envB.endTime + 0.02);
   }
 
+  saberSwing(opts = {}) {
+    if (this.isMuted) return; this.ensure();
+    const a = this.ctx; const t0 = a.currentTime + 0.001;
+    const pan = this._makePan(opts.pan);
+    const vol = opts.volume != null ? opts.volume : 1;
+    const o = a.createOscillator(); o.type = 'sawtooth';
+    o.frequency.setValueAtTime(280, t0);
+    o.frequency.exponentialRampToValueAtTime(160, t0 + 0.25);
+    const bp = a.createBiquadFilter(); bp.type = 'bandpass'; bp.frequency.value = 260; bp.Q.value = 1.8;
+    const e = this._env({ a: 0.02, d: 0.25, g: 0.35 * vol, t0 });
+    o.connect(bp).connect(e.node).connect(pan).connect(this.master);
+    this._tapFx(e.node, 0.08);
+    o.start(t0); o.stop(e.endTime + 0.02);
+  }
+
+  saberHit(opts = {}) {
+    if (this.isMuted) return; this.ensure();
+    const a = this.ctx; const t0 = a.currentTime + 0.001;
+    const pan = this._makePan(opts.pan);
+    const vol = opts.volume != null ? opts.volume : 1;
+    const nd = 0.04; const nb = a.createBuffer(1, (nd * a.sampleRate) | 0, a.sampleRate);
+    const ch = nb.getChannelData(0); for (let i = 0; i < ch.length; i++) ch[i] = Math.random() * 2 - 1;
+    const n = a.createBufferSource(); n.buffer = nb; n.playbackRate.value = this._rv(0.98, 1.02);
+    const bp = a.createBiquadFilter(); bp.type = 'bandpass'; bp.frequency.value = 900; bp.Q.value = 0.9;
+    const envN = this._env({ a: 0.001, d: 0.12, g: 0.6 * vol, t0 });
+    n.connect(bp).connect(envN.node).connect(pan).connect(this.master);
+    this._tapFx(envN.node, 0.12);
+    const o = a.createOscillator(); o.type = 'square';
+    o.frequency.setValueAtTime(620, t0); o.frequency.exponentialRampToValueAtTime(200, t0 + 0.1);
+    const envO = this._env({ a: 0.001, d: 0.08, g: 0.24 * vol, t0 });
+    o.connect(envO.node).connect(pan).connect(this.master);
+    this._tapFx(envO.node, 0.05);
+    n.start(t0); n.stop(envN.endTime + 0.01);
+    o.start(t0); o.stop(envO.endTime + 0.02);
+  }
+
   reload() {
     if (this.isMuted) return; this.ensure();
     const a = this.ctx; const t0 = a.currentTime + 0.001;

--- a/src/weapons/beamsaber.js
+++ b/src/weapons/beamsaber.js
@@ -24,7 +24,7 @@ export class BeamSaber extends Weapon {
     const hits = candidates.length ? raycaster.intersectObjects(candidates, true) : [];
     const handled = new Set();
 
-    if (S && S.shot) S.shot('saber');
+    if (S?.saberSwing) S.saberSwing();
     effects?.spawnSaberSlash?.(origin, end);
 
     for (const hit of hits) {
@@ -37,6 +37,7 @@ export class BeamSaber extends Weapon {
       try { window._HUD && window._HUD.showHitmarker && window._HUD.showHitmarker(); } catch(_) {}
       obj.userData.hp -= 40;
       applyKnockback?.(obj, dir.clone().multiplyScalar(0.25));
+      if (S?.saberHit) S.saberHit();
       if (S && S.impactFlesh) S.impactFlesh();
       if (S && S.enemyPain) S.enemyPain(obj?.userData?.type || 'grunt');
 
@@ -62,6 +63,7 @@ export class BeamSaber extends Weapon {
       const worldHits = raycaster.intersectObjects(objects, true);
       if (worldHits.length) {
         const h = worldHits[0];
+        if (S?.saberHit) S.saberHit();
         // optional: minimal spark could be triggered here if available
       }
     }


### PR DESCRIPTION
## Summary
- add saber swing and hit sounds to SFX
- beam saber weapon triggers swing and hit audio cues

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a7991eecbc83228977a1cde8fb92ea