### PR TITLE
Add BeamSaber charge feedback and cancel logic

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -499,8 +499,16 @@ try { weaponView.setWeapon(weaponSystem.getPrimaryName()); } catch(_) {}
 progression = new Progression({ weaponSystem, documentRef: document, onPause: (lock)=>{ offerActive = !!lock; paused = !!lock; }, controls });
 story = storyDisabled ? null : new StoryManager({ documentRef: document, onPause: (lock)=>{ paused = !!lock; }, controls, toastFn: (t)=> showToast(t), beatsUrl: 'assets/story/beats.json' });
 
-window.addEventListener('mousedown', e=>{ if(!controls.isLocked || paused) return; weaponSystem.triggerDown(); });
-window.addEventListener('mouseup', ()=>{ weaponSystem.triggerUp(); });
+window.addEventListener('mousedown', e=>{
+  if (!controls.isLocked || paused) return;
+  if (e.button === 2) weaponSystem.triggerAltDown();
+  else weaponSystem.triggerDown();
+});
+window.addEventListener('mouseup', e=>{
+  if (e.button === 2) weaponSystem.triggerAltUp();
+  else weaponSystem.triggerUp();
+});
+window.addEventListener('contextmenu', e=>{ e.preventDefault(); });
 window.addEventListener('keydown', e=>{
   if(e.code==='KeyR'){ weaponSystem.reload(); }
   if(e.code==='KeyP'){ paused=!paused; }

--- a/src/sfx.js
+++ b/src/sfx.js
@@ -194,6 +194,25 @@ export class SFX {
     o.start(t0); o.stop(envO.endTime + 0.02);
   }
 
+  saberCharge(){
+    if (this.isMuted) return null; this.ensure();
+    const a = this.ctx; const t0 = a.currentTime + 0.001;
+    const o = a.createOscillator(); o.type = 'sawtooth';
+    o.frequency.setValueAtTime(220, t0);
+    const g = a.createGain(); g.gain.setValueAtTime(0.0001, t0);
+    o.connect(g).connect(this.master); this._tapFx(g, 0.05);
+    g.gain.linearRampToValueAtTime(0.25, t0 + 0.1);
+    o.start(t0);
+    return {
+      stop: ()=>{
+        const now = a.currentTime;
+        g.gain.cancelScheduledValues(now);
+        g.gain.linearRampToValueAtTime(0.0001, now + 0.05);
+        try { o.stop(now + 0.06); } catch(_) {}
+      }
+    };
+  }
+
   reload() {
     if (this.isMuted) return; this.ensure();
     const a = this.ctx; const t0 = a.currentTime + 0.001;

--- a/src/weapons/base.js
+++ b/src/weapons/base.js
@@ -54,6 +54,16 @@ export class Weapon {
     this._triggerHeld = false;
   }
 
+  // Optional alternate fire; default no-op
+  // eslint-disable-next-line no-unused-vars
+  altTriggerDown(ctx) {}
+
+  // eslint-disable-next-line no-unused-vars
+  altTriggerUp(ctx) {}
+
+  // eslint-disable-next-line no-unused-vars
+  altTriggerCancel(ctx) {}
+
   update(dt, ctx) { // for auto fire sustain
     // Block sustain if weapon view is reloading (if provided in ctx)
     if (this.mode === 'auto' && this._triggerHeld && !(ctx && ctx.weaponView && ctx.weaponView.isReloading && ctx.weaponView.isReloading())) {

--- a/src/weapons/system.js
+++ b/src/weapons/system.js
@@ -108,6 +108,16 @@ export class WeaponSystem {
 
   triggerUp() { this.current?.triggerUp(); }
 
+  triggerAltDown() {
+    const w = this.current; if (!w) return;
+    if (typeof w.altTriggerDown === 'function') w.altTriggerDown(this.context());
+  }
+
+  triggerAltUp() {
+    const w = this.current; if (!w) return;
+    if (typeof w.altTriggerUp === 'function') w.altTriggerUp(this.context());
+  }
+
   reload() {
     const ok = this.current?.reload(() => this.S?.reload?.());
     if (ok) {
@@ -132,6 +142,11 @@ export class WeaponSystem {
   switchSlot(slotIndex1Based) {
     const idx = (slotIndex1Based | 0) - 1;
     if (idx >= 0 && idx < this.inventory.length) {
+      const old = this.current;
+      if (old) {
+        old.triggerUp();
+        if (typeof old.altTriggerCancel === 'function') old.altTriggerCancel(this.context());
+      }
       this.currentIndex = idx;
       this.updateHUD?.();
     }
@@ -140,6 +155,10 @@ export class WeaponSystem {
   // Swap primary to a new weapon instance and convert reserve from old
   swapPrimary(makeWeaponFn) {
     const old = this.current;
+    if (old) {
+      old.triggerUp();
+      if (typeof old.altTriggerCancel === 'function') old.altTriggerCancel(this.context());
+    }
     const carry = Math.floor(Math.max(0, (old?.reserveAmmo || 0)) * 0.5);
     const newW = makeWeaponFn();
     newW.reset();


### PR DESCRIPTION
## Summary
- brighten the BeamSaber blade and play a hum while charging
- allow weapons to cancel alternate-fire actions and stop charging when swapping guns
- add a saberCharge sound effect to accompany heavy strike charging

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a8233edacc8322bed84d49820f63bb