### PR TITLE
Register circle arena floor for collision detection

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -178,6 +178,8 @@ const enemyManager = new EnemyManager(
     return { position: pos, forward: f };
   }
 );
+// Ensure enemy manager colliders include arena floor and obstacles
+if (enemyManager.refreshColliders) enemyManager.refreshColliders(objects);
 // If map provided explicit enemy spawns, feed them to manager
 if (levelInfo && Array.isArray(levelInfo.enemySpawnPoints) && levelInfo.enemySpawnPoints.length) {
   enemyManager.customSpawnPoints = levelInfo.enemySpawnPoints;

--- a/src/world.js
+++ b/src/world.js
@@ -146,6 +146,7 @@ export function createWorld(THREE, rng = Math.random, arenaShape = 'box'){
         arenaRadius = 40;
         const floor = new THREE.Mesh(new THREE.CircleGeometry(arenaRadius, 32), mats.floor);
         floor.rotation.x = -Math.PI/2; floor.position.y = -0.01; floor.receiveShadow = !!enableShadows; scene.add(floor);
+        objects.push(floor);
         const wallShape = new THREE.Shape();
         wallShape.absarc(0, 0, arenaRadius + wallT/2, 0, Math.PI * 2, false);
         const holePath = new THREE.Path();


### PR DESCRIPTION
## Summary
- Include circle arena floor mesh in collidable objects to provide accurate ground hits
- Refresh enemy manager colliders after world creation so new objects are recognized

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a83c2eb5f48322872f0ecff1447cee