### PR TITLE
Fix enemy spawns in circular arena

### DIFF
--- a/src/world.js
+++ b/src/world.js
@@ -146,7 +146,12 @@ export function createWorld(THREE, rng = Math.random, arenaShape = 'box'){
         arenaRadius = 40;
         const floor = new THREE.Mesh(new THREE.CircleGeometry(arenaRadius, 32), mats.floor);
         floor.rotation.x = -Math.PI/2; floor.position.y = -0.01; floor.receiveShadow = !!enableShadows; scene.add(floor);
-        objects.push(floor);
+        // The floor should not be part of the collider list; including it
+        // prevents enemy spawn locations from being considered valid in the
+        // circular arena because its bounding box covers the entire play area.
+        // Unlike box/other arenas (which already omit the floor), we skip
+        // pushing the circular floor into `objects` so that only actual
+        // obstacles contribute to collision checks.
         const wallShape = new THREE.Shape();
         wallShape.absarc(0, 0, arenaRadius + wallT/2, 0, Math.PI * 2, false);
         const holePath = new THREE.Path();


### PR DESCRIPTION
## Summary
- Exclude circular floor from collider list to avoid blocking spawn detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a84d21adf083228af96b5ba22eb443