### PR TITLE
Ignore pistol in emergency ammo check

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -711,6 +711,7 @@ function step(){
         let totalAmmo = 0;
         try {
           for (const w of (weaponSystem.inventory || [])) {
+            if (w?.name === 'Pistol') continue;
             const mag = Math.max(0, (typeof w.getAmmo === 'function' ? w.getAmmo() : w.ammoInMag) | 0);
             const res = Math.max(0, (typeof w.getReserve === 'function' ? w.getReserve() : w.reserveAmmo) | 0);
             totalAmmo += mag + res;


### PR DESCRIPTION
## Summary
- Skip counting pistol ammo in emergency ammo assistance so fallback drops occur when primary weapons are empty

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a86776aa90832297921e9a4f1ae67f