### PR TITLE
Handle waves without bosses

### DIFF
--- a/src/bosses/manager.js
+++ b/src/bosses/manager.js
@@ -46,7 +46,7 @@ export class BossManager {
   startBoss(wave) {
     const THREE = this.THREE;
     this.reset();
-    this.active = true; this.wave = wave;
+    this.wave = wave;
 
     // Spawn position: prefer manager's spawn selection, else fallback near far edge
     const spawnPos = (typeof this.enemyManager._chooseSpawnPos === 'function'
@@ -77,7 +77,10 @@ export class BossManager {
     } else if (wave == 35) {
       boss = new StrikeAdjudicator({ THREE, mats: this.mats, spawnPos, enemyManager: this.enemyManager });
     }
-    
+
+    if (!boss) return false;
+
+    this.active = true;
     boss._notifyDeath = () => this._onBossDeath();
     this.enemyManager.registerExternalEnemy(boss, { countsTowardAlive: true });
     this.boss = boss;
@@ -85,6 +88,7 @@ export class BossManager {
     // First ability window 8–12s
     this.cooldown = 8 + Math.random() * 4;
     this.telegraphTime = 0;
+    return true;
   }
 
   update(dt, ctx) {

--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -591,9 +591,11 @@ export class EnemyManager {
     if (this.suspendWaves) return; // disabled in test harness
     // Gate boss waves
     if (this.wave % 5 === 0) {
-      if (this.onWave) this.onWave(this.wave, 1);
-      this.bossManager.startBoss(this.wave);
-      return;
+      const started = this.bossManager.startBoss(this.wave);
+      if (started) {
+        if (this.onWave) this.onWave(this.wave, 1);
+        return;
+      }
     }
 
     const count = 10 + this.wave;

--- a/src/main.js
+++ b/src/main.js
@@ -1028,10 +1028,11 @@ if (enemyManager && enemyManager.bossManager) {
       if (currentSongIndex < 0) currentSongIndex = 0;
       loadCurrentSong();
     }
-    originalStartBoss(wave);
+    const res = originalStartBoss(wave);
     try { if (story) story.onBossStart(wave); } catch(_) {}
     // Record boss max HP for intensity mapping
     try { bm._musicBossMaxHp = bm?.boss?.root?.userData?.hp || bm?.boss?.maxHp || 1; } catch (_) { bm._musicBossMaxHp = 1; }
+    return res;
   };
   const originalOnBossDeath = bm._onBossDeath.bind(bm);
   bm._onBossDeath = () => {


### PR DESCRIPTION
## Summary
- Avoid accessing undefined boss entries by letting `BossManager.startBoss` return false when no boss is defined for the wave
- Fall back to normal enemy waves when `startBoss` returns false
- Propagate `startBoss` return value through music wrapper

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a87e809a5483229c4dc3b2ed043e1c