### PR TITLE
Preserve altitude for flying knockback

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -454,7 +454,17 @@ export class EnemyManager {
   applyKnockback(enemy, vector) {
     if (!enemy || !vector) return;
     const step = vector.clone ? vector.clone() : new this.THREE.Vector3(vector.x || 0, vector.y || 0, vector.z || 0);
-    this._moveWithCollisions(enemy, step);
+    const type = enemy.userData?.type || '';
+    if (type === 'swarm_warden' || type.startsWith('flyer')) {
+      const horiz = step.clone();
+      horiz.y = 0;
+      const oldY = enemy.position.y;
+      this._moveWithCollisions(enemy, horiz);
+      const dip = Math.max(-0.3, Math.min(0.3, step.y || 0));
+      enemy.position.y = oldY + dip;
+    } else {
+      this._moveWithCollisions(enemy, step);
+    }
   }
 
   _moveWithCollisions(enemy, step) {


### PR DESCRIPTION
## Summary
- keep warden and flyer enemies from diving into ground when hit
- limit knockback vertical drop to small dip while keeping wall collisions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9655027f083228ce1292c4645c219