### PR TITLE
Improve enemy navigation with pathfinding

### DIFF
--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,130 @@
+export class PathFinder {
+  constructor(obstacles = [], opts = {}) {
+    this.cellSize = opts.cellSize || 1;
+    this.climbable = opts.climbable ?? 1;
+    this.grid = new Set();
+    this.bounds = { minX: 0, maxX: 0, minZ: 0, maxZ: 0 };
+    this.lastDuration = 0;
+    this.setObstacles(obstacles);
+  }
+
+  setObstacles(obstacles = []) {
+    this.obstacles = obstacles;
+    this.grid.clear();
+    const cs = this.cellSize;
+    let minX = Infinity, maxX = -Infinity, minZ = Infinity, maxZ = -Infinity;
+    for (const bb of obstacles) {
+      const height = bb.max.y - bb.min.y;
+      if (height <= this.climbable) continue;
+      const x0 = Math.floor(bb.min.x / cs);
+      const x1 = Math.floor(bb.max.x / cs);
+      const z0 = Math.floor(bb.min.z / cs);
+      const z1 = Math.floor(bb.max.z / cs);
+      for (let x = x0; x <= x1; x++) {
+        for (let z = z0; z <= z1; z++) {
+          this.grid.add(x + ',' + z);
+        }
+      }
+      if (x0 < minX) minX = x0;
+      if (x1 > maxX) maxX = x1;
+      if (z0 < minZ) minZ = z0;
+      if (z1 > maxZ) maxZ = z1;
+    }
+    if (!isFinite(minX)) { minX = maxX = minZ = maxZ = 0; }
+    this.bounds = { minX, maxX, minZ, maxZ };
+  }
+
+  _isBlockedCell(ix, iz) {
+    return this.grid.has(ix + ',' + iz);
+  }
+
+  isBlocked(x, z) {
+    const cs = this.cellSize;
+    const ix = Math.round(x / cs);
+    const iz = Math.round(z / cs);
+    return this._isBlockedCell(ix, iz);
+  }
+
+  findPath(start, goal) {
+    const t0 = (typeof performance !== 'undefined' && performance.now)
+      ? performance.now()
+      : Date.now();
+
+    const cs = this.cellSize;
+    const sx = Math.round(start.x / cs);
+    const sz = Math.round(start.z / cs);
+    const gx = Math.round(goal.x / cs);
+    const gz = Math.round(goal.z / cs);
+
+    let minX = Math.min(this.bounds.minX, sx, gx) - 1;
+    let maxX = Math.max(this.bounds.maxX, sx, gx) + 1;
+    let minZ = Math.min(this.bounds.minZ, sz, gz) - 1;
+    let maxZ = Math.max(this.bounds.maxZ, sz, gz) + 1;
+    const width = maxX - minX + 1;
+    const toIndex = (ix, iz) => (iz - minZ) * width + (ix - minX);
+
+    const open = new Map();
+    const closed = new Set();
+    const startKey = toIndex(sx, sz);
+    const startNode = { x: sx, z: sz, g: 0, f: Math.abs(gx - sx) + Math.abs(gz - sz), parent: null };
+    open.set(startKey, startNode);
+
+    const dirs = [
+      [1, 0],
+      [-1, 0],
+      [0, 1],
+      [0, -1]
+    ];
+
+    while (open.size) {
+      let currentKey = null;
+      let currentNode = null;
+      let bestF = Infinity;
+      for (const [k, n] of open) {
+        if (n.f < bestF) {
+          bestF = n.f;
+          currentKey = k;
+          currentNode = n;
+        }
+      }
+      if (!currentNode) break;
+      if (currentNode.x === gx && currentNode.z === gz) {
+        const out = [];
+        let c = currentNode;
+        while (c) {
+          out.push({ x: c.x * cs, z: c.z * cs });
+          c = c.parent;
+        }
+        this.lastDuration = ((typeof performance !== 'undefined' && performance.now)
+          ? performance.now()
+          : Date.now()) - t0;
+        return out.reverse();
+      }
+      open.delete(currentKey);
+      closed.add(currentKey);
+
+      for (const [dx, dz] of dirs) {
+        const nx = currentNode.x + dx;
+        const nz = currentNode.z + dz;
+        if (nx < minX || nx > maxX || nz < minZ || nz > maxZ) continue;
+        const nKey = toIndex(nx, nz);
+        if (closed.has(nKey)) continue;
+        if (this._isBlockedCell(nx, nz)) {
+          closed.add(nKey);
+          continue;
+        }
+        const g = currentNode.g + 1;
+        const h = Math.abs(gx - nx) + Math.abs(gz - nz);
+        const f = g + h;
+        const existing = open.get(nKey);
+        if (!existing || g < existing.g) {
+          open.set(nKey, { x: nx, z: nz, g, f, parent: currentNode });
+        }
+      }
+    }
+    this.lastDuration = ((typeof performance !== 'undefined' && performance.now)
+      ? performance.now()
+      : Date.now()) - t0;
+    return [];
+  }
+}

--- a/test/enemy_collision.test.js
+++ b/test/enemy_collision.test.js
@@ -1,0 +1,65 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { EnemyManager } from '../src/enemies/manager.js';
+
+class Vector3 {
+  constructor(x=0,y=0,z=0){ this.x=x; this.y=y; this.z=z; }
+  set(x,y,z){ this.x=x; this.y=y; this.z=z; return this; }
+}
+
+class Box3 {
+  constructor(min = new Vector3(), max = new Vector3()) { this.min = min; this.max = max; }
+  set(min, max){ this.min = new Vector3(min.x, min.y, min.z); this.max = new Vector3(max.x, max.y, max.z); return this; }
+  setFromObject(o){ return this.set(o.min, o.max); }
+  intersectsBox(box){
+    return !(box.max.x < this.min.x || box.min.x > this.max.x ||
+             box.max.y < this.min.y || box.min.y > this.max.y ||
+             box.max.z < this.min.z || box.min.z > this.max.z);
+  }
+}
+
+class Raycaster { set(){} }
+
+const THREE = { Vector3, Box3, Raycaster };
+
+class TestEnemyManager extends EnemyManager {
+  _initBulletPools() {}
+}
+
+function mkManager(obbs, groundFn) {
+  const mgr = new TestEnemyManager(THREE, {}, {}, [], null, Infinity, null);
+  mgr.objectBBs = obbs;
+  mgr.objects = [];
+  mgr._groundHeightAt = groundFn;
+  return mgr;
+}
+
+test('enemy steps over small obstacle', () => {
+  const obb = new Box3(new Vector3(0.5,0,-0.5), new Vector3(1.5,0.15,0.5));
+  const ground = (x,z) => (x>=0.5 && x<=1.5 && z>=-0.5 && z<=0.5) ? 0.15 : 0;
+  const mgr = mkManager([obb], ground);
+  const enemy = { position: new Vector3(0,0.8,0) };
+  mgr._moveWithCollisions(enemy, new Vector3(1,0,0));
+  assert.ok(Math.abs(enemy.position.x - 1) < 1e-6);
+  assert.ok(Math.abs(enemy.position.y - 0.95) < 1e-6);
+});
+
+test('enemy blocked by tall obstacle', () => {
+  const obb = new Box3(new Vector3(0.5,0,-0.5), new Vector3(1.5,0.6,0.5));
+  const ground = (x,z) => (x>=0.5 && x<=1.5 && z>=-0.5 && z<=0.5) ? 0.6 : 0;
+  const mgr = mkManager([obb], ground);
+  const enemy = { position: new Vector3(0,0.8,0) };
+  mgr._moveWithCollisions(enemy, new Vector3(1,0,0));
+  assert.strictEqual(enemy.position.x, 0);
+  assert.strictEqual(enemy.position.y, 0.8);
+});
+
+test('enemy lifts even without ground height data', () => {
+  const obb = new Box3(new Vector3(0.5,0,-0.5), new Vector3(1.5,0.15,0.5));
+  const ground = () => 0; // sensor fails to report obstacle height
+  const mgr = mkManager([obb], ground);
+  const enemy = { position: new Vector3(0,0.8,0) };
+  mgr._moveWithCollisions(enemy, new Vector3(1,0,0));
+  assert.ok(Math.abs(enemy.position.x - 1) < 1e-6);
+  assert.ok(Math.abs(enemy.position.y - 0.95) < 1e-6);
+});

--- a/test/pathfinding.test.js
+++ b/test/pathfinding.test.js
@@ -1,0 +1,20 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { PathFinder } from '../src/path.js';
+
+class Vector3 {
+  constructor(x=0,y=0,z=0){ this.x=x; this.y=y; this.z=z; }
+}
+class Box3 {
+  constructor(min=new Vector3(), max=new Vector3()){ this.min=min; this.max=max; }
+}
+
+test('pathfinder navigates around obstacle', () => {
+  const obstacle = new Box3(new Vector3(0,0,0), new Vector3(2,2,2));
+  const pf = new PathFinder([obstacle], { climbable: 0.5, cellSize: 1 });
+  const path = pf.findPath({ x: -1, z: 0 }, { x: 3, z: 0 });
+  assert.ok(path.length > 0);
+  for (const p of path) {
+    assert.ok(p.x < 0 || p.x > 2 || p.z < 0 || p.z > 2);
+  }
+});


### PR DESCRIPTION
## Summary
- Preserve vertical lift when ground sensor misses obstacle so enemies can mount low props
- Add grid-based pathfinding and expose `findPath` in enemy manager
- Cache path results, track timing, and surface profiling stats for debugging
- Have melee and rusher enemies request and follow paths when stuck, detouring around obstacles
- Add unit tests for pathfinding detours and vertical lift fallback

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a885152e6083228810ec53b018eb78