### PR TITLE
Link weather system to wave progression

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -431,6 +431,7 @@ enemyManager.onWave = (_wave, startingAlive) => {
   enemyManager.waveStartingAlive = startingAlive || 0;
   updateHUD();
   pickups.onWave(enemyManager.wave);
+  if (weather && typeof weather.onWave === 'function') weather.onWave();
   if (player.refreshColliders) player.refreshColliders(objects);
   if (progression) progression.onWave(enemyManager.wave);
   if (story) story.onWave(enemyManager.wave);


### PR DESCRIPTION
## Summary
- Replace time-based weather cycling with wave-based durations
- Ensure clear weather lasts no more than three waves
- Trigger weather updates at wave start

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a33ec8448322abb75ca897b8b357