### PR TITLE
Persist and highlight quality/music settings

### DIFF
--- a/i18n/en.json
+++ b/i18n/en.json
@@ -55,6 +55,7 @@
   "settings.title": "Settings",
   "settings.quality": "Quality",
   "settings.sound": "Sound",
+  "settings.music": "Music",
   "settings.mouse": "Mouse",
   "settings.volume": "Volume",
   "settings.sensitivity": "Sensitivity",

--- a/i18n/uk.json
+++ b/i18n/uk.json
@@ -55,6 +55,7 @@
   "settings.title": "Налаштування",
   "settings.quality": "Якість",
   "settings.sound": "Звук",
+  "settings.music": "Музика",
   "settings.mouse": "Миша",
   "settings.volume": "Гучність",
   "settings.sensitivity": "Чутливість",

--- a/index.html
+++ b/index.html
@@ -92,10 +92,6 @@
     <div class="pill" data-i18n="feature.procedural">Procedural arena</div>
   </div>
   <div style="display:flex; justify-content:center; gap:8px; margin:12px 0; flex-wrap:wrap">
-    <select id="musicSelect" class="secondary startSelect" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
-      <option value="library" data-i18n="music.library">chatGPT 5 music</option>
-      <option value="suno" data-i18n="music.suno">Suno Remix</option>
-    </select>
     <!-- <select id="arenaShape" class="secondary startSelect" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;"> -->
     <select id="arenaShape" class="secondary startSelect" style="display: none !important">
       <option value="box" data-i18n="arena.box">Box Arena</option>
@@ -103,7 +99,7 @@
       <option value="diamond" data-i18n="arena.diamond">Diamond Arena</option>
       <option value="triangle" data-i18n="arena.triangle">Triangle Arena</option>
       <option value="pi" data-i18n="arena.pi">П Arena</option>
-    </select>
+      </select>
     <select id="langSelect" class="secondary startSelect" style="cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a;">
       <option value="en" data-i18n="lang.english">English</option>
       <option value="uk" data-i18n="lang.ukrainian">Ukrainian</option>
@@ -144,6 +140,13 @@
     <div class="pill setting">
       <label for="soundVolume" data-i18n="settings.volume">Volume</label>
       <input type="range" id="soundVolume" min="0" max="1" step="0.05" />
+    </div>
+    <div class="pill setting">
+      <label for="musicSelect" data-i18n="settings.music">Music</label>
+      <select id="musicSelect" class="secondary">
+        <option value="library" data-i18n="music.library">chatGPT 5 music</option>
+        <option value="suno" data-i18n="music.suno">Suno Remix</option>
+      </select>
     </div>
   </div>
   <div class="settingsGroup">

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -22,11 +22,13 @@ h1{ margin:6px 0 4px; font-size: clamp(26px,5vw,44px);} h1 span{ color:#22c55e }
 button{ cursor:pointer; border:0; border-radius:14px; padding:12px 16px; font-weight:900; box-shadow:0 12px 36px #0000002a; }
 .primary{ background:linear-gradient(180deg,#22c55e,#86efac); color:#062e12 }
 .secondary{ background:linear-gradient(180deg,#60a5fa,#a5b4fc); color:#0b2458 }
+button.selected{ outline:4px solid #3b82f6; }
 .tiny{ font-size:12px; opacity:.8 }
 .settingsGroup{ display:flex; flex-direction:column; gap:10px; margin:12px auto 0; width:fit-content; }
 .settingsGroup .setting{ display:flex; align-items:center; gap:8px; }
 .settingsGroup .setting label{ font-weight:800; }
 .settingsGroup .setting input[type="range"]{ width:120px; }
+.settingsGroup .setting select{ cursor:pointer; border:0; border-radius:8px; padding:4px 8px; font-weight:800; box-shadow:0 4px 12px #0000001a; }
 #crosshair{ position:fixed; left:50%; top:50%; width:20px; height:20px; margin-left:-10px; margin-top:-10px; pointer-events:none; opacity: var(--xh-alpha); transform: rotate(var(--xh-rot)) scale(var(--xh-scale)); transform-origin: center center; transition: transform 90ms linear, opacity 90ms linear }
 #crosshair .seg{ position:absolute; background: var(--xh); transition: top 90ms linear, left 90ms linear, width 90ms linear, height 90ms linear }
 #crosshair .seg.top{ left:50%; top: calc(50% - var(--xh-gap) - var(--xh-len)); width: var(--xh-thick); height: var(--xh-len); transform: translateX(-50%); }


### PR DESCRIPTION
## Summary
- Move music source selector into settings and switch tracks immediately when changed
- Highlight selected quality preset and remember the choice across sessions
- Style settings controls with a selected outline and add i18n for music label

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a95d277e38832286bb5febd6376331