### PR TITLE
Reduce news ticker speed

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1133,7 +1133,7 @@ function showTicker(text, repeat = 1, interval = 8000){
       }
 
       const distance = track.offsetWidth + containerWidth;
-      const baseSpeed = containerWidth / (interval/1000);
+      const baseSpeed = containerWidth / (interval/1000) / 2.5;
       const duration = distance / baseSpeed;
       track.style.animation = `tickerScroll ${duration}s linear`;
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -103,7 +103,7 @@ button.selected{ outline:4px solid #3b82f6; }
   font-weight:800;
   padding:6px 12px;
   will-change:transform;
-  animation: tickerScroll 10s linear;
+  animation: tickerScroll 25s linear;
 }
 .ticker-track .ticker-item{
   display:inline-block;


### PR DESCRIPTION
## Summary
- Slow news ticker animation by factor of 2.5 for easier reading

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a9b263a65483228aa6e4871fb67de4