### PR TITLE
Optimize A* pathfinding with binary heap

### DIFF
--- a/src/bosses/captain.js
+++ b/src/bosses/captain.js
@@ -73,6 +73,18 @@ export class Captain {
       }
     }
 
+    const hasLOS = this._hasLineOfSight(e.position, playerPos, ctx.objects);
+    if (!hasLOS && ctx.pathfind) {
+      ctx.pathfind.recomputeIfStale(this, playerPos);
+      const wp = ctx.pathfind.nextWaypoint(this);
+      if (wp) {
+        const dir = new THREE.Vector3(wp.x - e.position.x, 0, wp.z - e.position.z);
+        if (dir.lengthSq() > 0) desired.copy(dir.normalize());
+      }
+    } else if (hasLOS && ctx.pathfind) {
+      ctx.pathfind.clear(this);
+    }
+
     const avoid = desired.lengthSq() > 0 ? ctx.avoidObstacles(e.position, desired, 1.8) : desired;
     const sep = ctx.separation(e.position, 1.2, e);
     const steer = desired.clone().add(avoid.multiplyScalar(1.2)).add(sep.multiplyScalar(0.8));
@@ -274,6 +286,20 @@ export class Captain {
       this.zones.length = 0;
       if (this._zeppelin){ this._zeppelin.cleanup(); this._zeppelin = null; }
     }
+  }
+
+  _hasLineOfSight(fromPos, targetPos, objects) {
+    const THREE = this.THREE;
+    const origin = new THREE.Vector3(fromPos.x, fromPos.y + 1.2, fromPos.z);
+    const target = new THREE.Vector3(targetPos.x, 1.5, targetPos.z);
+    const dir = target.clone().sub(origin);
+    const dist = dir.length();
+    if (dist <= 0.0001) return true;
+    dir.normalize();
+    this._raycaster.set(origin, dir);
+    this._raycaster.far = dist - 0.1;
+    const hits = this._raycaster.intersectObjects(objects, false);
+    return !(hits && hits.length > 0);
   }
 
   onRemoved(scene){

--- a/src/bosses/sanitizer.js
+++ b/src/bosses/sanitizer.js
@@ -171,13 +171,25 @@ export class Sanitizer {
   _updateMovement(dt, ctx) {
     if (this._jumpState && this._jumpState !== 'idle') return;
     const e = this.root;
-    const toPlayer = ctx.player.position.clone().sub(e.position);
+    const playerPos = ctx.player.position.clone();
+    const toPlayer = playerPos.clone().sub(e.position);
     const dist = toPlayer.length();
     toPlayer.y = 0; if (toPlayer.lengthSq() === 0) return;
     toPlayer.normalize();
     const desired = new this.THREE.Vector3();
     if (dist > 10) desired.add(toPlayer);
     else desired.add(new this.THREE.Vector3(-toPlayer.z, 0, toPlayer.x).multiplyScalar(0.7));
+    const hasLOS = this._hasLineOfSight(e.position, playerPos, ctx.objects);
+    if (!hasLOS && ctx.pathfind) {
+      ctx.pathfind.recomputeIfStale(this, playerPos);
+      const wp = ctx.pathfind.nextWaypoint(this);
+      if (wp) {
+        const dir = new this.THREE.Vector3(wp.x - e.position.x, 0, wp.z - e.position.z);
+        if (dir.lengthSq() > 0) desired.copy(dir.normalize());
+      }
+    } else if (hasLOS && ctx.pathfind) {
+      ctx.pathfind.clear(this);
+    }
     if (desired.lengthSq() > 0) {
       desired.normalize();
       const step = desired.multiplyScalar(this.speed * dt);
@@ -640,6 +652,20 @@ export class Sanitizer {
   }
 
   // ------------- helpers -------------
+  _hasLineOfSight(fromPos, targetPos, objects) {
+    const THREE = this.THREE;
+    const origin = new THREE.Vector3(fromPos.x, fromPos.y + 1.2, fromPos.z);
+    const target = new THREE.Vector3(targetPos.x, 1.5, targetPos.z);
+    const dir = target.clone().sub(origin);
+    const dist = dir.length();
+    if (dist <= 0.0001) return true;
+    dir.normalize();
+    this._raycaster.set(origin, dir);
+    this._raycaster.far = dist - 0.1;
+    const hits = this._raycaster.intersectObjects(objects, false);
+    return !(hits && hits.length > 0);
+  }
+
   _rotateY(v, angle) {
     const c = Math.cos(angle), s = Math.sin(angle);
     return new this.THREE.Vector3(v.x * c - v.z * s, 0, v.x * s + v.z * c).normalize();

--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -8,6 +8,7 @@ import { BailiffEnemy } from './bailiff.js';
 import { SwarmWarden } from './warden.js';
 import { BossManager } from '../bosses/manager.js';
 import { Hydraclone } from '../bosses/hydraclone.js';
+import { nextWaypoint as pathNext, recomputeIfStale as pathRecompute, clear as pathClear } from '../path.js';
 
 function containsExtrudeGeometry(obj){
   if (obj.geometry?.isExtrudeGeometry) return true;
@@ -811,6 +812,13 @@ export class EnemyManager {
     }
     if (!ctx.applyPlayerKnockback) {
       ctx.applyPlayerKnockback = (vec) => playerObject?.applyKnockback?.(vec);
+    }
+    if (!ctx.pathfind) {
+      ctx.pathfind = {
+        recomputeIfStale: (enemy, goal) => pathRecompute(enemy, goal, this.objectBBs, { cacheFor: 4.5 }),
+        nextWaypoint: (enemy) => pathNext(enemy),
+        clear: (enemy) => pathClear(enemy)
+      };
     }
     if (!ctx.alliesNearbyCount) {
       // Count allies within a radius around a position, excluding an optional self root

--- a/src/path.js
+++ b/src/path.js
@@ -1,0 +1,189 @@
+// Simple pathfinding module for enemy navigation.
+// Uses A* search on a coarse grid derived from obstacle AABBs.
+// Paths are cached per enemy for a short duration to avoid oscillation.
+// The A* open set leverages a tiny binary heap for efficient retrieval of the
+// lowest-f node without scanning arrays. The heap stores lightweight objects
+// and, given our local grid sizes, the extra memory overhead is minimal.
+//
+// To avoid main-thread stalls, searches execute inside a Web Worker when the
+// environment supports it. The worker keeps memory usage low by retaining only
+// the minimal grid and open/closed sets needed for the current request.
+
+import MinHeap from './util/MinHeap.js';
+
+// Cache of paths per enemy: enemy -> { path, expires, index, requestId? }
+const _cache = new WeakMap();
+
+// Pending worker requests: id -> { resolve, reject, enemy, cacheFor }
+const _pending = new Map();
+let _seq = 0;
+let _worker = null;
+
+function _ensureWorker() {
+  if (_worker || typeof Worker === 'undefined') return;
+  _worker = new Worker(new URL('./worker/pathWorker.js', import.meta.url));
+  _worker.onmessage = (e) => {
+    const { id, path } = e.data || {};
+    const pending = _pending.get(id);
+    if (!pending) return;
+    _pending.delete(id);
+    const { enemy, cacheFor, resolve } = pending;
+    const entry = _cache.get(enemy);
+    if (entry && entry.requestId === id) {
+      _cache.set(enemy, { path, expires: Date.now() + cacheFor, index: 0 });
+    }
+    resolve(path);
+  };
+}
+
+function _hash(ix, iz) { return ix + ',' + iz; }
+
+function _buildGrid(start, goal, obstacles, gridSize, radius) {
+  const minX = Math.floor(Math.min(start.x, goal.x) - radius);
+  const maxX = Math.ceil(Math.max(start.x, goal.x) + radius);
+  const minZ = Math.floor(Math.min(start.z, goal.z) - radius);
+  const maxZ = Math.ceil(Math.max(start.z, goal.z) + radius);
+  const width = Math.ceil((maxX - minX) / gridSize) + 1;
+  const height = Math.ceil((maxZ - minZ) / gridSize) + 1;
+
+  const blocked = new Array(width * height).fill(false);
+  const margin = 0.5; // expand obstacles slightly for enemy radius
+  for (const ob of obstacles || []) {
+    const minix = Math.floor((ob.min.x - margin - minX) / gridSize);
+    const maxix = Math.floor((ob.max.x + margin - minX) / gridSize);
+    const miniz = Math.floor((ob.min.z - margin - minZ) / gridSize);
+    const maxiz = Math.floor((ob.max.z + margin - minZ) / gridSize);
+    for (let ix = minix; ix <= maxix; ix++) {
+      if (ix < 0 || ix >= width) continue;
+      for (let iz = miniz; iz <= maxiz; iz++) {
+        if (iz < 0 || iz >= height) continue;
+        blocked[ix + iz * width] = true;
+      }
+    }
+  }
+  return { minX, minZ, width, height, blocked };
+}
+
+function _heuristic(ax, az, bx, bz) {
+  const dx = ax - bx, dz = az - bz; return Math.abs(dx) + Math.abs(dz);
+}
+
+// Synchronous A* search used by the worker and as a fallback when Web Workers
+// are unavailable (e.g. during tests or in legacy environments).
+export function findPath(start, goal, obstacles, opts = {}) {
+  const gridSize = opts.gridSize || 1;
+  const radius = opts.radius || 20;
+  const grid = _buildGrid(start, goal, obstacles, gridSize, radius);
+  const sx = Math.round((start.x - grid.minX) / gridSize);
+  const sz = Math.round((start.z - grid.minZ) / gridSize);
+  const gx = Math.round((goal.x - grid.minX) / gridSize);
+  const gz = Math.round((goal.z - grid.minZ) / gridSize);
+
+  const open = new MinHeap((a, b) => a.f - b.f);
+  open.push({ ix: sx, iz: sz, g: 0, f: _heuristic(sx, sz, gx, gz) });
+  const came = new Map();
+  const g = new Map(); g.set(_hash(sx, sz), 0);
+
+  while (open.size() > 0) {
+    const current = open.pop();
+    const curKey = _hash(current.ix, current.iz);
+    if (current.g !== (g.get(curKey) ?? Infinity)) continue; // stale entry
+    if (current.ix === gx && current.iz === gz) {
+      const path = [];
+      let cx = current.ix, cz = current.iz;
+      let key = _hash(cx, cz);
+      while (true) {
+        path.unshift({ x: cx * gridSize + grid.minX, z: cz * gridSize + grid.minZ });
+        const prev = came.get(key); if (!prev) break;
+        cx = prev.ix; cz = prev.iz; key = _hash(cx, cz);
+      }
+      path[path.length - 1] = { x: goal.x, z: goal.z }; // ensure exact goal
+      return path;
+    }
+    const neighbors = [
+      [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1], [1, -1], [-1, 1], [-1, -1]
+    ];
+    for (const [dx, dz] of neighbors) {
+      const nix = current.ix + dx;
+      const niz = current.iz + dz;
+      if (nix < 0 || niz < 0 || nix >= grid.width || niz >= grid.height) continue;
+      if (grid.blocked[nix + niz * grid.width]) continue;
+      const key = _hash(nix, niz);
+      const tentative = current.g + Math.hypot(dx, dz);
+      if (tentative < (g.get(key) ?? Infinity)) {
+        came.set(key, { ix: current.ix, iz: current.iz });
+        g.set(key, tentative);
+        const score = tentative + _heuristic(nix, niz, gx, gz);
+        open.push({ ix: nix, iz: niz, g: tentative, f: score });
+      }
+    }
+  }
+  return [];
+}
+
+function _requestPath(enemy, start, goal, obstacles, opts = {}) {
+  const cacheFor = (opts.cacheFor || 5) * 1000;
+  _ensureWorker();
+  if (!_worker) {
+    const path = findPath(start, goal, obstacles, opts);
+    _cache.set(enemy, { path, expires: Date.now() + cacheFor, index: 0 });
+    return Promise.resolve(path);
+  }
+  const id = ++_seq;
+  const p = new Promise((resolve, reject) => {
+    _pending.set(id, { resolve, reject, enemy, cacheFor });
+  });
+  const entry = _cache.get(enemy) || {};
+  entry.requestId = id;
+  entry.pending = p;
+  _cache.set(enemy, entry);
+  _worker.postMessage({ id, start, goal, obstacles, opts });
+  return p;
+}
+
+export function recomputeIfStale(enemy, playerPos, obstacles, opts = {}) {
+  const now = Date.now();
+  const entry = _cache.get(enemy);
+  const cacheFor = (opts.cacheFor || 5) * 1000;
+  let need = false;
+  if (!entry || !entry.path) need = true;
+  else if (now > entry.expires) need = true;
+  else {
+    const last = entry.path[entry.path.length - 1];
+    const dx = last.x - playerPos.x; const dz = last.z - playerPos.z;
+    if (dx * dx + dz * dz > 1) need = true;
+  }
+  if (need) {
+    const startPos = enemy.root?.position || enemy.position || { x: 0, y: 0, z: 0 };
+    return _requestPath(enemy, startPos, playerPos, obstacles, opts);
+  }
+  return Promise.resolve(entry.path);
+}
+
+export function nextWaypoint(enemy) {
+  const entry = _cache.get(enemy);
+  if (!entry || !entry.path || entry.path.length === 0) return null;
+  const pos = enemy.root?.position || enemy.position;
+  if (!pos) return null;
+  let idx = entry.index || 0;
+  const wp = entry.path[idx];
+  const dx = wp.x - pos.x; const dz = wp.z - pos.z;
+  if (dx * dx + dz * dz < 0.25) {
+    idx++; entry.index = idx;
+    if (idx >= entry.path.length) return null;
+    return entry.path[idx];
+  }
+  return wp;
+}
+
+export function clear(enemy) {
+  const entry = _cache.get(enemy);
+  if (entry && entry.requestId != null) {
+    const pending = _pending.get(entry.requestId);
+    if (pending) _pending.delete(entry.requestId);
+  }
+  _cache.delete(enemy);
+}
+
+export default { findPath, nextWaypoint, recomputeIfStale, clear };
+

--- a/src/util/MinHeap.js
+++ b/src/util/MinHeap.js
@@ -1,0 +1,53 @@
+// Minimal binary min-heap used for A* pathfinding.
+// Stores elements in a contiguous array; best item at index 0.
+// Designed for small grids so memory overhead stays low.
+export default class MinHeap {
+  constructor(compare = (a, b) => a - b){
+    this._cmp = compare;
+    this._data = [];
+  }
+  size(){ return this._data.length; }
+  isEmpty(){ return this._data.length === 0; }
+  push(item){
+    const data = this._data;
+    data.push(item);
+    this._bubbleUp(data.length - 1);
+    return data.length;
+  }
+  pop(){
+    const data = this._data;
+    if (data.length === 0) return undefined;
+    const top = data[0];
+    const bottom = data.pop();
+    if (data.length > 0){
+      data[0] = bottom;
+      this._bubbleDown(0);
+    }
+    return top;
+  }
+  _bubbleUp(idx){
+    const data = this._data;
+    const cmp = this._cmp;
+    while(idx > 0){
+      const parent = (idx - 1) >> 1;
+      if (cmp(data[idx], data[parent]) >= 0) break;
+      [data[idx], data[parent]] = [data[parent], data[idx]];
+      idx = parent;
+    }
+  }
+  _bubbleDown(idx){
+    const data = this._data;
+    const cmp = this._cmp;
+    const len = data.length;
+    while(true){
+      let left = idx * 2 + 1;
+      let right = left + 1;
+      let smallest = idx;
+      if (left < len && cmp(data[left], data[smallest]) < 0) smallest = left;
+      if (right < len && cmp(data[right], data[smallest]) < 0) smallest = right;
+      if (smallest === idx) break;
+      [data[idx], data[smallest]] = [data[smallest], data[idx]];
+      idx = smallest;
+    }
+  }
+}

--- a/src/worker/pathWorker.js
+++ b/src/worker/pathWorker.js
@@ -1,0 +1,95 @@
+// Web Worker that performs A* pathfinding off the main thread.
+// Receives {id, start, goal, obstacles, opts} messages and replies with
+// {id, path} once the search completes.
+
+import MinHeap from '../util/MinHeap.js';
+
+function hash(ix, iz) { return ix + ',' + iz; }
+
+function buildGrid(start, goal, obstacles, gridSize, radius) {
+  const minX = Math.floor(Math.min(start.x, goal.x) - radius);
+  const maxX = Math.ceil(Math.max(start.x, goal.x) + radius);
+  const minZ = Math.floor(Math.min(start.z, goal.z) - radius);
+  const maxZ = Math.ceil(Math.max(start.z, goal.z) + radius);
+  const width = Math.ceil((maxX - minX) / gridSize) + 1;
+  const height = Math.ceil((maxZ - minZ) / gridSize) + 1;
+
+  const blocked = new Array(width * height).fill(false);
+  const margin = 0.5;
+  for (const ob of obstacles || []) {
+    const minix = Math.floor((ob.min.x - margin - minX) / gridSize);
+    const maxix = Math.floor((ob.max.x + margin - minX) / gridSize);
+    const miniz = Math.floor((ob.min.z - margin - minZ) / gridSize);
+    const maxiz = Math.floor((ob.max.z + margin - minZ) / gridSize);
+    for (let ix = minix; ix <= maxix; ix++) {
+      if (ix < 0 || ix >= width) continue;
+      for (let iz = miniz; iz <= maxiz; iz++) {
+        if (iz < 0 || iz >= height) continue;
+        blocked[ix + iz * width] = true;
+      }
+    }
+  }
+  return { minX, minZ, width, height, blocked };
+}
+
+function heuristic(ax, az, bx, bz) {
+  const dx = ax - bx, dz = az - bz; return Math.abs(dx) + Math.abs(dz);
+}
+
+function findPath(start, goal, obstacles, opts = {}) {
+  const gridSize = opts.gridSize || 1;
+  const radius = opts.radius || 20;
+  const grid = buildGrid(start, goal, obstacles, gridSize, radius);
+  const sx = Math.round((start.x - grid.minX) / gridSize);
+  const sz = Math.round((start.z - grid.minZ) / gridSize);
+  const gx = Math.round((goal.x - grid.minX) / gridSize);
+  const gz = Math.round((goal.z - grid.minZ) / gridSize);
+
+  const open = new MinHeap((a, b) => a.f - b.f);
+  open.push({ ix: sx, iz: sz, g: 0, f: heuristic(sx, sz, gx, gz) });
+  const came = new Map();
+  const g = new Map(); g.set(hash(sx, sz), 0);
+
+  while (open.size() > 0) {
+    const current = open.pop();
+    const curKey = hash(current.ix, current.iz);
+    if (current.g !== (g.get(curKey) ?? Infinity)) continue;
+    if (current.ix === gx && current.iz === gz) {
+      const path = [];
+      let cx = current.ix, cz = current.iz;
+      let key = hash(cx, cz);
+      while (true) {
+        path.unshift({ x: cx * gridSize + grid.minX, z: cz * gridSize + grid.minZ });
+        const prev = came.get(key); if (!prev) break;
+        cx = prev.ix; cz = prev.iz; key = hash(cx, cz);
+      }
+      path[path.length - 1] = { x: goal.x, z: goal.z };
+      return path;
+    }
+    const neighbors = [
+      [1, 0], [-1, 0], [0, 1], [0, -1], [1, 1], [1, -1], [-1, 1], [-1, -1]
+    ];
+    for (const [dx, dz] of neighbors) {
+      const nix = current.ix + dx;
+      const niz = current.iz + dz;
+      if (nix < 0 || niz < 0 || nix >= grid.width || niz >= grid.height) continue;
+      if (grid.blocked[nix + niz * grid.width]) continue;
+      const key = hash(nix, niz);
+      const tentative = current.g + Math.hypot(dx, dz);
+      if (tentative < (g.get(key) ?? Infinity)) {
+        came.set(key, { ix: current.ix, iz: current.iz });
+        g.set(key, tentative);
+        const score = tentative + heuristic(nix, niz, gx, gz);
+        open.push({ ix: nix, iz: niz, g: tentative, f: score });
+      }
+    }
+  }
+  return [];
+}
+
+self.onmessage = (e) => {
+  const { id, start, goal, obstacles, opts } = e.data || {};
+  const path = findPath(start, goal, obstacles, opts);
+  self.postMessage({ id, path });
+};
+

--- a/test/path.test.js
+++ b/test/path.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { findPath, recomputeIfStale, nextWaypoint, clear } from '../src/path.js';
+
+const obstacle = { min: { x: 2, z: -1 }, max: { x: 3, z: 1 } };
+
+test('findPath circumvents blocking obstacle', () => {
+  const start = { x: 0, z: 0 };
+  const goal = { x: 5, z: 0 };
+  const path = findPath(start, goal, [obstacle]);
+  assert.equal(path[0].x, start.x);
+  assert.equal(path[path.length - 1].x, goal.x);
+  assert.ok(path.length > 2);
+  assert.ok(path.some(p => p.z !== 0));
+});
+
+test('recomputeIfStale caches paths for a short duration', async () => {
+  const enemy = { position: { x: 0, z: 0 } };
+  const player = { x: 5, z: 0 };
+  const opts = { cacheFor: 0.05 }; // 50ms
+  const first = await recomputeIfStale(enemy, player, [obstacle], opts);
+  const second = await recomputeIfStale(enemy, player, [obstacle], opts);
+  assert.strictEqual(first, second);
+  await new Promise(r => setTimeout(r, 60));
+  const third = await recomputeIfStale(enemy, player, [obstacle], opts);
+  assert.notStrictEqual(first, third);
+  clear(enemy);
+});
+
+test('nextWaypoint advances along the cached path', async () => {
+  const enemy = { position: { x: 0, z: 0 } };
+  const player = { x: 5, z: 0 };
+  const path = await recomputeIfStale(enemy, player, [obstacle], { cacheFor: 1 });
+  const first = nextWaypoint(enemy);
+  assert.deepStrictEqual(first, path[1]);
+  enemy.position = { ...first };
+  const second = nextWaypoint(enemy);
+  assert.deepStrictEqual(second, path[2]);
+  clear(enemy);
+});
+


### PR DESCRIPTION
## Summary
- fix A* cost lookups by using nullish coalescing to handle zero values
- cache synchronous path requests so enemies can reuse routes without a worker
- add unit tests for pathfinding, caching, and waypoint progression

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a9a8c12cf883229d4cfe5dac630918