### PR TITLE
Reset arena after tutorial

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1018,6 +1018,12 @@ function startGame(){
     controls.lock();
   }
   panel.parentElement.style.display = 'none';
+  // Restore default procedural level before starting a run
+  levelInfo = null;
+  obstacleManager.generate(seed, objects);
+  cullGrassUnderObjects(grassMesh, objects);
+  enemyManager.refreshColliders(objects);
+  enemyManager.customSpawnPoints = null;
   reset();
   if (musicChoice === 'suno') { playSuno(); } else { music.start(); }
 }
@@ -1058,6 +1064,12 @@ function finishTutorial(){
   if (!isMobile) {
     try { controls.unlock(); } catch (e) { logError(e); }
   }
+  // Regenerate the default arena so the next play session uses it
+  levelInfo = null;
+  obstacleManager.generate(seed, objects);
+  cullGrassUnderObjects(grassMesh, objects);
+  enemyManager.refreshColliders(objects);
+  enemyManager.customSpawnPoints = null;
   reset(true);
   showStartPanel();
 }


### PR DESCRIPTION
## Summary
- Regenerate default level and refresh colliders when starting a new game.
- Restore full arena after tutorial completion so future runs begin in normal play area.

## Testing
- `npm test`
- `npm run lint`
- `npm run resource-check`


------
https://chatgpt.com/codex/tasks/task_e_68b5cc019c5483228c31c2a6c4c944fb