### PR TITLE
Remove map reload on game start

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -1024,19 +1024,7 @@ function startGame(){
     controls.lock();
   }
   panel.parentElement.style.display = 'none';
-  // Reload whichever map is active so each run starts fresh
-  if (currentMap) {
-    levelInfo = obstacleManager.loadFromMap(currentMap, objects);
-    cullGrassUnderObjects(grassMesh, objects);
-    enemyManager.refreshColliders(objects);
-    enemyManager.customSpawnPoints = levelInfo.enemySpawnPoints;
-  } else {
-    obstacleManager.generate(seed, objects);
-    cullGrassUnderObjects(grassMesh, objects);
-    enemyManager.refreshColliders(objects);
-    levelInfo = null;
-    enemyManager.customSpawnPoints = null;
-  }
+  
   reset();
   if (musicChoice === 'suno') { playSuno(); } else { music.start(); }
 }


### PR DESCRIPTION
## Summary
- Start game without regenerating or reloading arena
- Preserve existing level info and spawn points during reset

## Testing
- `npm test`
- `npm run lint`
- `npm run resource-check`


------
https://chatgpt.com/codex/tasks/task_e_68b5d402b7648322bdfdcbe338588516