### PR TITLE
Reset arena after tutorial

### DIFF
--- a/src/enemies/manager.js
+++ b/src/enemies/manager.js
@@ -84,6 +84,11 @@ export class EnemyManager {
     this._initBulletPools();
   }
 
+  setArenaRadius(radius){
+    this.arenaRadius = radius;
+    this.spawnRings = this._computeSpawnRings();
+  }
+
   // Rebuild collidable AABBs after the shared objects list changes (e.g., obstacles destroyed)
   refreshColliders(objects = this.objects) {
     this.objects = objects;

--- a/src/world.js
+++ b/src/world.js
@@ -4,7 +4,9 @@
 import { createGrassMesh } from './graphics/grass.js';
 import { logError } from './util/log.js';
 
-export const ARENA_RADIUS = 40 / 3;
+export const DEFAULT_ARENA_RADIUS = 40;
+export let ARENA_RADIUS = DEFAULT_ARENA_RADIUS;
+export function setArenaRadius(r){ ARENA_RADIUS = r; }
 
 export function createWorld(THREE, rng = Math.random, arenaShape = 'box'){
   // Renderer


### PR DESCRIPTION
## Summary
- Expose configurable arena radius with a default of 40 units
- Clear tutorial map before runs and restore full arena radius
- Allow EnemyManager to update spawn rings when the arena size changes

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b5d69fc69883229c255fe6ec6d3db6